### PR TITLE
[AV-1087] vm: use LRU for block cache

### DIFF
--- a/vm/chain_vm.go
+++ b/vm/chain_vm.go
@@ -36,6 +36,7 @@ func (vm *VM) Rejected(b *chain.StatelessBlock) {
 }
 
 func (vm *VM) Accepted(b *chain.StatelessBlock) {
+	vm.blocks.Put(b.ID(), b)
 	delete(vm.verifiedBlocks, b.ID())
 	vm.lastAccepted = b.ID()
 	log.Debug("accepted block", "id", b.ID())

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2019-2021, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package vm
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/cache"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/quarkvm/chain"
+)
+
+func TestBlockCache(t *testing.T) {
+	// create a block with "Unknown" status
+	blk := &chain.StatelessBlock{
+		StatefulBlock: &chain.StatefulBlock{
+			Prnt:       ids.GenerateTestID(),
+			Hght:       10000,
+			Difficulty: 1000,
+			Cost:       100,
+		},
+	}
+	blkID := blk.ID()
+
+	vm := VM{
+		blocks:         &cache.LRU{Size: 3},
+		verifiedBlocks: make(map[ids.ID]*chain.StatelessBlock),
+	}
+
+	// put the block into the cache "vm.blocks"
+	// and delete from "vm.verifiedBlocks"
+	vm.Accepted(blk)
+
+	// we have not set up any persistent db
+	// so this must succeed from using cache
+	blk2, err := vm.getBlock(blkID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(blk, blk2) {
+		t.Fatalf("block expected %+v, got %+v", blk, blk2)
+	}
+}


### PR DESCRIPTION
Cache for each "Verified" call and evict on "Reject". To optimize `VM.lookback` calls.