### PR TITLE
use ubuntu 20.04 to make release

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -33,7 +33,7 @@ jobs:
           E2E: true
   build_test_release:
     needs: [build_test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -33,7 +33,7 @@ jobs:
           E2E: true
   build_test_release:
     needs: [build_test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04 # don't compile using latest/22.04 due to dynamic libs issue with 20.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
There are issues with compiling using ubuntu-latest or ubuntu-22.04 due to dynamics libs there not compatible with 20.04. Using 20.04 to generate release satisfy libs deps on both os versions.